### PR TITLE
use alpine and link statically on linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: docker build --build-arg IMAGE=centos:centos6 -t skaji/relocatable-perl -f build/Dockerfile .
+      - run: docker build --build-arg IMAGE=alpine --build-arg LINKTYPE=static -t skaji/relocatable-perl -f build/Dockerfile .
       - run: bash build/github-actions.sh linux_amd64_create_artifacts
       - uses: actions/upload-artifact@v2
         with:
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
-      - run: docker buildx build --platform linux/arm64 --build-arg IMAGE=centos:centos7 -t skaji/relocatable-perl -f build/Dockerfile --load .
+      - run: docker buildx build --platform linux/arm64 --build-arg IMAGE=alpine --build-arg LINKTYPE=static -t skaji/relocatable-perl -f build/Dockerfile --load .
       - run: bash build/github-actions.sh linux_arm64_create_artifacts
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: docker build --build-arg IMAGE=centos:centos6 -t skaji/relocatable-perl -f build/Dockerfile .
+      - run: docker build --build-arg IMAGE=alpine --build-arg LINKTYPE=static -t skaji/relocatable-perl -f build/Dockerfile .
       - run: bash build/github-actions.sh linux_amd64_create_artifacts
       - uses: actions/upload-artifact@v2
         with:
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
-      - run: docker buildx build --platform linux/arm64 --build-arg IMAGE=centos:centos7 -t skaji/relocatable-perl -f build/Dockerfile --load .
+      - run: docker buildx build --platform linux/arm64 --build-arg IMAGE=alpine --build-arg LINKTYPE=static -t skaji/relocatable-perl -f build/Dockerfile --load .
       - run: bash build/github-actions.sh linux_arm64_create_artifacts
       - uses: actions/upload-artifact@v2
         with:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,15 +1,24 @@
 ARG IMAGE
 FROM $IMAGE
 ARG IMAGE
+ARG LINKTYPE=dynamic
 
 RUN if [[ $IMAGE = centos:centos6 ]]; then sed -i 's/^#baseurl=/baseurl=/g; s/^mirrorlist=/#mirrorlist=/g; s/http:\/\/mirror.centos.org/https:\/\/vault.centos.org/g' /etc/yum.repos.d/CentOS-Base.repo; fi
-RUN yum install -y \
+RUN if [[ $IMAGE != alpine* ]]; then yum install -y \
     gcc \
     make \
     tar \
     curl \
     patch \
-    xz
+    xz; \
+    fi
+RUN if [[ $IMAGE == alpine* ]]; then apk add --no-cache \
+    build-base \
+    libc6-compat \
+    perl \
+    curl \
+    xz; \
+    fi
 RUN mkdir -p \
     /lib \
     /lib/$(uname -m)-linux-gnu \
@@ -23,8 +32,8 @@ RUN mkdir /perl
 RUN curl -fsSL https://github.com/skaji/relocatable-perl/releases/download/5.36.0.0/perl-$(uname -m)-linux.tar.xz | tar xJf - --strip-components 1 -C /perl
 RUN curl -fsSL --compressed -o /cpm https://raw.githubusercontent.com/skaji/cpm/main/cpm
 COPY build/relocatable-perl-build build/cpm.yml BUILD_VERSION /
-RUN /perl/bin/perl /cpm install -g
-RUN /perl/bin/perl /relocatable-perl-build --perl_version $(cat /BUILD_VERSION) --prefix /opt/perl
+RUN perl /cpm install -g
+RUN perl /relocatable-perl-build --perl_version $(cat /BUILD_VERSION) --prefix /opt/perl "--linktype=${LINKTYPE}"
 RUN /opt/perl/bin/perl /cpm install -g App::cpanminus App::ChangeShebang
 RUN /opt/perl/bin/change-shebang -f /opt/perl/bin/*
 RUN set -eux; \

--- a/build/relocatable-perl-build
+++ b/build/relocatable-perl-build
@@ -39,6 +39,7 @@ relocatable-perl-build - building perl with relocatable settings
     --perl_version   install perl version
     --tarball        use local tar.gz
     --jobs           parallel build, default: 1
+    --linktype       linkt type ("dynamic" vs "static" perl executable), default: dynamic
     --help, -h       show this help message
 
     Examples:
@@ -57,6 +58,7 @@ GetOptions
     "perl_version=s" => \(my $perl_version),
     "tarball=s"      => \(my $tarball),
     "jobs=i"         => \(my $jobs),
+    "linktype=s"     => \(my $linktype = "dynamic"),
     "help|h"         => sub { pod2usage(0) },
 or pod2usage(1);
 
@@ -72,7 +74,7 @@ if (!-d $prefix) {
     die "don't have write permission to $prefix\n";
 }
 
-perl_build($prefix, $perl_version, $tarball);
+perl_build($prefix, $perl_version, $tarball, $linktype);
 force_symlink($prefix, $perl_version);
 
 my $config_heavy = `$prefix/bin/perldoc -lm Config_heavy.pl`;
@@ -91,7 +93,7 @@ system "$prefix/bin/perl -V";
 exit;
 
 sub perl_build {
-    my ($prefix, $perl_version, $tarball) = @_;
+    my ($prefix, $perl_version, $tarball, $linktype) = @_;
 
     my $current_dir = getcwd;
 
@@ -126,6 +128,10 @@ sub perl_build {
         "-DDEBUGGING=-g",
         "-des",
     );
+    if ($linktype eq "static") {
+        push @Configure, "-Uusedl";
+        push @Configure, "-Dldflags=-static";
+    }
     if ($^O eq "linux") {
         # ubuntu 18.04 does not have xlocale.h
         # we can safely remove xlocale.h because locale.h reads it


### PR DESCRIPTION
To make the perl toolchain more portable, it should be statically linked (at least for linux).
This PR adds support to build perl on alpine and (optionally) sets the link type to create a fully static perl executable.

```shell-session
file linux-*/perl-linux-*/bin/perl
linux-amd64/perl-linux-amd64/bin/perl: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, with debug_info, not stripped
linux-arm64/perl-linux-arm64/bin/perl: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, with debug_info, not stripped
```

This also resolves #13 and helps resolve https://github.com/bazelbuild/rules_perl/issues/54.