### PR TITLE
Added Power and s390x architecture support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,18 @@ jobs:
         with:
           name: linux-arm64
           path: linux-arm64
+  linux-ppc64le:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - run: docker buildx build --platform linux/ppc64le -t skaji/relocatable-perl -f build/Dockerfile --load .
+      - run: bash build/github-actions.sh linux_ppc64le_create_artifacts
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-ppc64le
+          path: linux-ppc64le
   darwin-amd64:
     runs-on: macos-13
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,18 @@ jobs:
         with:
           name: linux-arm64
           path: linux-arm64
+  linux-ppc64le:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - run: docker buildx build --platform linux/ppc64le -t skaji/relocatable-perl-ppc64le -f build/Dockerfile .
+      - run: bash build/github-actions.sh linux_ppc64le_create_artifacts
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-ppc64le
+          path: linux-ppc64le
   darwin-amd64:
     runs-on: macos-13
     steps:
@@ -63,6 +75,7 @@ jobs:
     needs:
       - linux-amd64
       - linux-arm64
+      - linux-ppc64le
       - darwin-amd64
       - darwin-arm64
     steps:
@@ -74,6 +87,10 @@ jobs:
         with:
           name: linux-arm64
           path: linux-arm64
+      - uses: actions/download-artifact@v4
+        with:
+          name: linux-ppc64le
+          path: linux-ppc64le
       - uses: actions/download-artifact@v4
         with:
           name: darwin-amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
-      - run: docker buildx build --platform linux/ppc64le -t skaji/relocatable-perl-ppc64le -f build/Dockerfile .
+      - run: docker buildx build --platform linux/ppc64le -t skaji/relocatable-perl -f build/Dockerfile .
       - run: bash build/github-actions.sh linux_ppc64le_create_artifacts
       - uses: actions/upload-artifact@v4
         with:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos7
+FROM redhat/ubi8:latest
 
 # see https://gist.github.com/skaji/76203327b517cb44da88a4301de118d3
 RUN sed -i 's/override_install_langs=en_US.UTF-8/override_install_langs=en_US.utf8/' /etc/yum.conf
@@ -19,7 +19,7 @@ RUN mkdir -p \
     /usr/lib64 \
     /usr/local/lib \
     /usr/local/lib64
-RUN curl -fsSL https://raw.githubusercontent.com/skaji/relocatable-perl/main/perl-install | bash -s /perl
+RUN curl -fsSL https://raw.githubusercontent.com/npanpaliya/relocatable-perl/ppc-support/perl-install | bash -s /perl
 RUN curl -fsSL --compressed -o /cpm https://raw.githubusercontent.com/skaji/cpm/main/cpm
 COPY build/relocatable-perl-build build/cpm.yml BUILD_VERSION /
 RUN /perl/bin/perl /cpm install -g
@@ -28,7 +28,7 @@ RUN /opt/perl/bin/perl /cpm install -g App::cpanminus App::ChangeShebang
 RUN /opt/perl/bin/change-shebang -f /opt/perl/bin/*
 RUN set -eux; \
   cd /tmp; \
-  _ARCHNAME=$(if [[ $(uname -m) = x86_64 ]]; then echo amd64; else echo arm64; fi); \
+  _ARCHNAME=$(if [[ $(uname -m) = x86_64 ]]; then echo amd64; elif [[ $(uname -m) = aarch64 ]]; then echo arm64; else echo $(uname -m); fi); \
   cp -r /opt/perl perl-linux-$_ARCHNAME; \
   tar cf perl-linux-$_ARCHNAME.tar perl-linux-$_ARCHNAME; \
   gzip -9 --stdout perl-linux-$_ARCHNAME.tar > /perl-linux-$_ARCHNAME.tar.gz; \

--- a/build/github-actions.sh
+++ b/build/github-actions.sh
@@ -6,6 +6,7 @@ mac_prepare_tools() {
   export HOMEBREW_NO_AUTO_UPDATE=1
   export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
   export HOMEBREW_NO_INSTALL_CLEANUP=1
+  unset GITHUB_ACTIONS
   brew unlink $(brew list --formula)
   brew install xz coreutils gnu-tar
   brew link --force xz coreutils gnu-tar

--- a/build/github-actions.sh
+++ b/build/github-actions.sh
@@ -51,6 +51,14 @@ linux_arm64_create_artifacts() {
   docker rm $ID
 }
 
+linux_ppc64le_create_artifacts() {
+  mkdir linux-ppc64le
+  ID=$(docker create --platform linux/ppc64le skaji/relocatable-perl)
+  docker cp $ID:/perl-linux-ppc64le.tar.gz linux-ppc64le/
+  docker cp $ID:/perl-linux-ppc64le.tar.xz linux-ppc64le/
+  docker rm $ID
+}
+
 case "$1" in
 mac_prepare_tools)
   mac_prepare_tools
@@ -66,6 +74,9 @@ linux_amd64_create_artifacts)
   ;;
 linux_arm64_create_artifacts)
   linux_arm64_create_artifacts
+  ;;
+linux_ppc64le_create_artifacts)
+  linux_ppc64le_create_artifacts
   ;;
 *)
   echo "unknown command: $1" >&2

--- a/perl-install
+++ b/perl-install
@@ -11,8 +11,6 @@ install_from_cpan() {
   INSTALL_DIR=$1
   PERL_VER=$2
   VERSION=${PERL_VER%.*}
-  $HTTP_GET=$3
-  $HTTP_GET_OPTION=$4
 
   $HTTP_GET $HTTP_GET_OPTION https://www.cpan.org/src/5.0/perl-${VERSION}.tar.gz -o perl.tar.gz \
     && tar -xzf perl.tar.gz \
@@ -79,7 +77,7 @@ fi
 ABS_INSTALL_DIR=$(cd $INSTALL_DIR &>/dev/null; pwd)
 
 if [[ $BUILD_FROM_CPAN = 1 ]]; then
-  install_from_cpan $INSTALL_DIR $LATEST_VERSION $HTTP_GET $HTTP_GET_OPTION
+  install_from_cpan $INSTALL_DIR $LATEST_VERSION
 
 else
   LATEST_URL=$(echo $LATEST_LINE | \cut -d, -f5)

--- a/perl-install
+++ b/perl-install
@@ -1,10 +1,27 @@
 #!/bin/bash
 
-set -eu
+set -exu
 
 die() {
   echo "$1" >&2
   exit 1
+}
+
+install_from_cpan() {
+  INSTALL_DIR=$1
+  PERL_VER=$2
+  VERSION=${PERL_VER%.*}
+  $HTTP_GET=$3
+  $HTTP_GET_OPTION=$4
+
+  $HTTP_GET $HTTP_GET_OPTION https://www.cpan.org/src/5.0/perl-${VERSION}.tar.gz -o perl.tar.gz \
+    && tar -xzf perl.tar.gz \
+    && cd perl-${VERSION} \
+    && ./Configure -des -Dprefix=$INSTALL_DIR \
+    && make \
+    && make install \
+    && rm -rf /perl.tar.gz perl-${VERSION}
+
 }
 
 if [[ $# -ne 1 ]] || [[ $1 = "-h" ]] || [[ $1 = "--help" ]]; then
@@ -38,31 +55,19 @@ else
 fi
 
 LATEST_LINE=$($HTTP_GET $HTTP_GET_OPTION https://raw.githubusercontent.com/skaji/relocatable-perl/main/releases.csv | (\grep -m 1 ,$_OS,$_ARCH,; cat >/dev/null))
+
+BUILD_FROM_CPAN=0
 if [[ -z $LATEST_LINE ]]; then
-  die "Failed to determine latest perl version"
-fi
-
-LATEST_VERSION=$(echo $LATEST_LINE | \cut -d, -f1)
-LATEST_URL=$(echo $LATEST_LINE | \cut -d, -f5)
-if [[ $PRINT_VERSION = "YES" ]]; then
-  echo $LATEST_VERSION
-  exit
-fi
-
-TAR_CMD=gtar
-if ! type $TAR_CMD &>/dev/null; then
-  TAR_CMD=tar
-  if ! type $TAR_CMD &>/dev/null; then
-    die 'Cannot find `tar` command'
+  if [[ $_ARCH = ppc64le || $_ARCH = s390x ]]; then
+     LATEST_LINE=$($HTTP_GET $HTTP_GET_OPTION https://raw.githubusercontent.com/skaji/relocatable-perl/main/releases.csv | (\grep -m 1 ,$_OS,amd64,; cat >/dev/null))
+     BUILD_FROM_CPAN=1
+  fi
+  if [[ -z $LATEST_LINE ]]; then
+    die "Failed to determine latest perl version"
   fi
 fi
 
-TAR_OPTION=xzf
-TAR_SUFFIX=tar.gz
-if type xz &>/dev/null; then
-  TAR_OPTION=xJf
-  TAR_SUFFIX=tar.xz
-fi
+LATEST_VERSION=$(echo $LATEST_LINE | \cut -d, -f1)
 
 INSTALL_DIR=$1
 if [[ -d $INSTALL_DIR ]]; then
@@ -73,9 +78,37 @@ else
 fi
 ABS_INSTALL_DIR=$(cd $INSTALL_DIR &>/dev/null; pwd)
 
-echo "Installing perl $LATEST_VERSION to $INSTALL_DIR, this may take a while..."
+if [[ $BUILD_FROM_CPAN = 1 ]]; then
+  install_from_cpan $INSTALL_DIR $LATEST_VERSION $HTTP_GET $HTTP_GET_OPTION
 
-$HTTP_GET $HTTP_GET_OPTION $LATEST_URL | $TAR_CMD $TAR_OPTION - --strip-components 1 -C $INSTALL_DIR
+else
+  LATEST_URL=$(echo $LATEST_LINE | \cut -d, -f5)
+  if [[ $PRINT_VERSION = "YES" ]]; then
+    echo $LATEST_VERSION
+    exit
+  fi
+
+  TAR_CMD=gtar
+  if ! type $TAR_CMD &>/dev/null; then
+    TAR_CMD=tar
+    if ! type $TAR_CMD &>/dev/null; then
+      die 'Cannot find `tar` command'
+    fi
+  fi
+
+  TAR_OPTION=xzf
+  TAR_SUFFIX=tar.gz
+  if type xz &>/dev/null; then
+    TAR_OPTION=xJf
+    TAR_SUFFIX=tar.xz
+  fi
+
+  echo "Installing perl $LATEST_VERSION to $INSTALL_DIR, this may take a while..."
+
+  $HTTP_GET $HTTP_GET_OPTION $LATEST_URL | $TAR_CMD $TAR_OPTION - --strip-components 1 -C $INSTALL_DIR
+
+fi
+
 if [[ ! -f $INSTALL_DIR/bin/perl ]]; then
   die "Failed to install perl"
 fi

--- a/releases.csv
+++ b/releases.csv
@@ -1,4 +1,12 @@
 version,os,arch,compress,url,padding
+5.40.0.0,linux,amd64,xz,https://github.com/skaji/relocatable-perl/releases/download/5.40.0.0/perl-linux-amd64.tar.xz,
+5.40.0.0,linux,amd64,gz,https://github.com/skaji/relocatable-perl/releases/download/5.40.0.0/perl-linux-amd64.tar.gz,
+5.40.0.0,linux,arm64,xz,https://github.com/skaji/relocatable-perl/releases/download/5.40.0.0/perl-linux-arm64.tar.xz,
+5.40.0.0,linux,arm64,gz,https://github.com/skaji/relocatable-perl/releases/download/5.40.0.0/perl-linux-arm64.tar.gz,
+5.40.0.0,darwin,amd64,xz,https://github.com/skaji/relocatable-perl/releases/download/5.40.0.0/perl-darwin-amd64.tar.xz,
+5.40.0.0,darwin,amd64,gz,https://github.com/skaji/relocatable-perl/releases/download/5.40.0.0/perl-darwin-amd64.tar.gz,
+5.40.0.0,darwin,arm64,xz,https://github.com/skaji/relocatable-perl/releases/download/5.40.0.0/perl-darwin-arm64.tar.xz,
+5.40.0.0,darwin,arm64,gz,https://github.com/skaji/relocatable-perl/releases/download/5.40.0.0/perl-darwin-arm64.tar.gz,
 5.38.2.0,linux,amd64,xz,https://github.com/skaji/relocatable-perl/releases/download/5.38.2.0/perl-linux-amd64.tar.xz,
 5.38.2.0,linux,amd64,gz,https://github.com/skaji/relocatable-perl/releases/download/5.38.2.0/perl-linux-amd64.tar.gz,
 5.38.2.0,linux,arm64,xz,https://github.com/skaji/relocatable-perl/releases/download/5.38.2.0/perl-linux-arm64.tar.xz,


### PR DESCRIPTION
For Power, perl-install script is modified to install perl from cpan for 1st time. Once power specific built artifact is uploaded on releases page, from next time, it should use the already available built artifact.