### PR TITLE
link libcrypt statically

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,6 @@ Copyright 2010- Tatsuhiko Miyagawa, licensed under the same terms as Perl.
 
 * [App::ChangeShebang](https://github.com/skaji/change-shebang)
 Copyright Shoichi Kaji, licensed under the same terms as Perl.
+
+* [libcrypt.a](https://sourceware.org/glibc/)
+Copyright (C) 1991-2015 Free Software Foundation, Inc. GNU Lesser General Public License version 2.1 or later.

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,3 +1,19 @@
+FROM buildpack-deps:bookworm AS static-libcrypt
+
+RUN set -eux; \
+  mkdir /libc6-dev; \
+  cd /tmp; \
+  if [ $(uname -m) = x86_64 ]; then \
+    curl -fsSL -O http://security.ubuntu.com/ubuntu/pool/main/g/glibc/libc6-dev_2.23-0ubuntu3_amd64.deb; \
+    dpkg-deb -x libc6-dev_2.23-0ubuntu3_amd64.deb /libc6-dev; \
+    cp /libc6-dev/usr/lib/x86_64-linux-gnu/libcrypt.a /libcrypt.a; \
+  else \
+    curl -fsSL -O http://ports.ubuntu.com/pool/main/g/glibc/libc6-dev_2.23-0ubuntu3_arm64.deb; \
+    dpkg-deb -x libc6-dev_2.23-0ubuntu3_arm64.deb /libc6-dev; \
+    cp /libc6-dev/usr/lib/aarch64-linux-gnu/libcrypt.a /libcrypt.a; \
+  fi; \
+  :
+
 FROM centos:centos7 AS builder
 
 # see https://gist.github.com/skaji/76203327b517cb44da88a4301de118d3
@@ -26,7 +42,16 @@ RUN mkdir -p \
 RUN curl -fsSL https://raw.githubusercontent.com/skaji/relocatable-perl/main/perl-install | bash -s /perl
 RUN curl -fsSL --compressed -o /cpm https://raw.githubusercontent.com/skaji/cpm/main/cpm
 RUN --mount=type=bind,target=src /perl/bin/perl /cpm install -g --cpmfile src/build/cpm.yml
+
+# RUN rm -f /usr/lib64/libcrypt.so /usr/lib64/libcrypt.so.1
+COPY --from=static-libcrypt /libcrypt.a /usr/lib64/libcrypt.a
 RUN --mount=type=bind,target=src /perl/bin/perl src/build/relocatable-perl-build --perl_version $(cat src/BUILD_VERSION) --prefix /opt/perl
+RUN cd /usr/lib64; \
+  rm -f libcrypt.a; \
+  ln -sf libcrypt-2.17.so libcrypt.so; \
+  ln -sf libcrypt-2.17.so libcrypt.so.1; \
+  :
+
 RUN /opt/perl/bin/perl /cpm install -g App::cpanminus App::ChangeShebang
 RUN /opt/perl/bin/change-shebang -f /opt/perl/bin/*
 RUN set -eux; \

--- a/build/relocatable-perl-build
+++ b/build/relocatable-perl-build
@@ -132,9 +132,12 @@ sub perl_build {
         # see https://github.com/agracio/electron-edge-js/issues/16
         push @Configure, "-Ui_xlocale";
 
-        # RHEL8, Fedora28, CentOS8 does not have libnsl.so.1 by default;
-        # remove -lnsl
+        # RHEL8, Fedora28, CentOS8 does not have libnsl.so.1 by default; remove -lnsl
         push @Configure, "-Dlibs=-lpthread -ldl -lm -lcrypt -lutil -lc";
+
+        # RHEL9 removes libcrypt.so.1 by default; so we will link libcrypt.a statically
+        # manually define d_crypt here
+        push @Configure, "-Dd_crypt";
 
         my $arch = (uname)[4];
         my @libpth = (
@@ -172,6 +175,9 @@ sub perl_build {
         }
     }
     say "---> building perl $perl_version, see $log for progress";
+    if ($^O eq "linux") {
+        system "rm -f /usr/lib64/libcrypt.so /usr/lib64/libcrypt.so.1"; # XXX
+    }
     run \@Configure, $log;
     my @option = $jobs ? ("--jobs=$jobs") : ();
     run ["make", @option, "install"], $log;


### PR DESCRIPTION
Fix #19 

## Summary

RHEL9 removes libcrypt.so.1, so we cannot run relocatable-perl on RHEL9:
```
❯ perl -v
perl: error while loading shared libraries: libcrypt.so.1: cannot open shared object file: No such file or directory
```

To fix this issue, we link libcrypt statically.

## Detail

Although glibc-static package provides libcrypt.a on centos7, it seems that the libcrypt.a is broken:
```
❯ ./Configure ...
...
❯ make
...
cc -fstack-protector-strong -L/usr/local/lib -o miniperl \
    opmini.o perlmini.o universalmini.o av.o builtin.o caretx.o class.o deb.o doio.o doop.o dquote.o dump.o globals.o gv.o hv.o keywords.o locale.o mathoms.o mg.o mro_core.o numeric.o pad.o peep.o perlio.o perly.o pp.o pp_ctl.o pp_hot.o pp_pack.o pp_sort.o pp_sys.o reentr.o regcomp.o regcomp_debug.o regcomp_invlist.o regcomp_study.o regcomp_trie.o regexec.o run.o scope.o sv.o taint.o time64.o toke.o utf8.o util.o   miniperlmain.o  -lpthread -ldl -lm -lcrypt -lutil -lc
/usr/lib/gcc/x86_64-redhat-linux/4.8.5/../../../../lib64/libcrypt.a(md5-crypt.o): In function `__md5_crypt_r':
(.text+0x10c): undefined reference to `NSSLOW_Init'
...
```

So, we use libcrypt.a in ubuntu libc6-dev package.

## Note

This issue was originally reported by @gugod 